### PR TITLE
Added comparison function that does not reveal to error what was compared.

### DIFF
--- a/data.php
+++ b/data.php
@@ -72,6 +72,14 @@ function valid_same(&$p,&$error=null,$valid=null){
 	return true;
 }
 
+function valid_same_anon(&$p,&$error=null,$valid=null){
+	if ($p[$valid['_input']]!=$p[$valid['same']]){
+		$error=!empty($valid['msg']) ? $valid['msg'] : 'This must be the same as the value above.';
+		return false;
+	}
+	return true;
+}
+
 function validate($validate,&$p=null,&$errors=null,$type=null,$clear=false){
 	$checked=array();
 	// this has to be done at the start as func validators may add new keys that are permitted


### PR DESCRIPTION
Added a copy of the valid_same function that does not include the value compared to in an error case.
This means that if comparing two passwords, or other secret data, it does not tell the user what they are trying to match if they fail to do so.
