### PR TITLE
Tighten make email

### DIFF
--- a/string.php
+++ b/string.php
@@ -282,7 +282,7 @@ function make_email(&$string,$blank=false){
 	if (strlen($string)>0){
 		$string=strtolower(trim($string));
 		$string=str_replace('\u0040','@',$string);
-		$pattern="/\b['a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}\b(?!\S)/";
+		$pattern="/\b['a-z0-9_%+-]+(?:\.['a-z0-9_%+-]+)*@[a-z0-9.-]+\.[a-z]{2,4}\b(?!\S)/";
 		$result=preg_match($pattern,$string,$matches,PREG_OFFSET_CAPTURE);
 		$matches=end($matches);
 		if ($result>0 and end($matches)==0){
@@ -309,7 +309,7 @@ function make_html($text, $tags = null){
 		$text = strip_tags($text, $tags);
 	}
 	$text = str_replace(['// <![CDATA['."\r\n","\r\n".'// ]]>'], '', $text);
-	
+
 	// HTML block tags that can be used
 	$htmltags = 'div|p|h[1-6]|blockquote';
 	// lists
@@ -318,52 +318,52 @@ function make_html($text, $tags = null){
 	$htmltags .= '|embed|object|select|form';
 	//tables
 	$htmltags .= '|table|thead|tfoot|tbody|tr|td|th';
-	
+
 	// random ones that exist so someone will use them
 	$htmltags .= '|address|math|caption|pre|code';
-	
+
 	// odd line, what does it do?
 	$text = str_replace('', '', $text);
 	$text = str_replace('<br />', '<br/>', $text);
-	
+
 	// make sure it uses a single line break character
 	$text = str_replace(["\r\n","\r"], "\n", $text);
-	
+
 	// add line breaks before and after
-	$text = preg_replace('!(<(?:'.$htmltags.')[^>]*>)!', "\n$1", $text); 
+	$text = preg_replace('!(<(?:'.$htmltags.')[^>]*>)!', "\n$1", $text);
 	$text = preg_replace('!(</(?:'.$htmltags.')>)!', "$1\n\n", $text);
-	
+
 	// tried adding this line to remove breaks after open tags but wouldn't work - regex works in regexr
-	//$text=preg_replace('!(<(?:'.$htmltags.')>)/\n<br/>!',"$1",$text); 
-	
+	//$text=preg_replace('!(<(?:'.$htmltags.')>)/\n<br/>!',"$1",$text);
+
 	// remove duplicate line breaks
 	$text = preg_replace("/\n\n+/", "\n\n", $text);
-	
+
 	// make everything into paragraphs
 	$text = preg_replace('|<p>(<br/>)*</p>|', '', $text);
 	$text = preg_replace('|<p>(&nbsp;)*</p>|', '', $text);
 	$text = preg_replace('/\n?(.+?)(?:\n\s*\n|\z)/s', "<p>$1</p>\n", $text);
-	
+
 	// delete any empty paragraphs
 	$text = preg_replace('|<p>\s*?</p>|',' ', $text);
 	$text = str_replace("\n<br/></p>", "", $text);
-	
+
 	// remove paragraphs if its round one of the tags above
 	$text = preg_replace('!<p>\s*(</?(?:'.$htmltags.')[^>]*>)\s*</p>!', "$1", $text);
-	
+
 	// lists inside lists can screw stuff up
 	$text = preg_replace("|<p>(<li.+?)</p>|", "$1", $text);
 	$text = preg_replace(" /<p>([A-Za-z0-9 '-,.;]*)<\/li>/xsm", "<p>$1</p></li>", $text);
-	
+
 	// if the quote has attributes then keep them but remove the paragraph from around it. then stick them inside
 	$text = preg_replace('|<p><blockquote([^>]*)>|i', "<blockquote$1><p>", $text);
 	$text = str_replace('</blockquote></p>', '</p></blockquote>', $text);
-	
+
 	// if the line breaks are odd it can start a paragraph
 	//  before a close tag, or close one afterwards, which isn't good
 	$text = preg_replace('!<p>\s*(</?(?:'.$htmltags.')[^>]*>)!', "$1", $text);
 	$text = preg_replace('!(</?(?:'.$htmltags.')[^>]*>)\s*</p>!', "$1", $text);
-	
+
 	// turn any remaining single breaks into <br/> tags, then remove them
 	//  from after block elements (or before the close tag)
 	$text = preg_replace('|(?<!<br/>)\s*\n|', "<br/>\n", $text);
@@ -372,7 +372,7 @@ function make_html($text, $tags = null){
 	$text = preg_replace('|<div>|', "", $text);
 	$text = preg_replace('|</div>|', "", $text);
 	$text = str_replace('&nbsp;', ' ', $text);
-	return $text; 
+	return $text;
 }
 
 /**

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -27,6 +27,18 @@ class TestFunctionsString extends PHPUnit_Framework_TestCase {
 		$email='me@m1ke.me>';
 		$this->assertFalse(make_email($email));
 	}
+	function testBadPeriodLocalPartStart(){
+		$email='.me@m1ke.me';
+		$this->assertFalse(make_email($email));
+	}
+	function testBadPeriodLocalPartEnd(){
+		$email='me.@m1ke.me';
+		$this->assertFalse(make_email($email));
+	}
+	function testBadPeriodLocalPartRepeated(){
+		$email='inferno..me@m1ke.me';
+		$this->assertFalse(make_email($email));
+	}
 
 	// Message split
 	function testShortMessageReturnsSingleItemArray(){
@@ -168,7 +180,7 @@ class TestFunctionsString extends PHPUnit_Framework_TestCase {
 		$first_word=first_word($test_string);
 		$this->assertEquals($first_word,'');
 	}
-	
+
 	// substr_words
 	function testSubstrWords(){
 		$sentence='The quick brown fox jumped over the lazy dog';
@@ -296,4 +308,3 @@ class TestPlural extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($plural,'1 '.$this->str);
 	}
 }
-


### PR DESCRIPTION
Changed make_email to not allow leading/trailing/repeated (no gaps) periods in the local-part, as per the email RFC definition.